### PR TITLE
feat: add STR file parser page

### DIFF
--- a/public/img/extract-str.png
+++ b/public/img/extract-str.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75860e54f9bf019d0a3838c74435ac3a829fa90142f09946b7f1b16fd2355202
+size 10569

--- a/public/locales/de-DE/translation.json
+++ b/public/locales/de-DE/translation.json
@@ -119,5 +119,19 @@
     "select-file": "Level-Datei",
     "short-description": "3D-Editor für Level-Dateien. \nWähle vorhandene Levels aus, um sie anzuzeigen und zu ändern! \n(Der Editor ist in Bearbeitung und die Funktionen sind eingeschränkt)",
     "title": "Level-Editor"
+  },
+  "str-parser": {
+    "title": "STR-Parser",
+    "short-description": "Analysiert und zeigt Thandor .str Textressourcen-Dateien mit lokalisierten Strings an.",
+    "select-file": ".str Datei auswählen",
+    "start": "Parser starten",
+    "error": {
+      "parse-failed": "Die .str-Datei konnte nicht analysiert werden."
+    },
+    "locale-count": "Anzahl Sprachen",
+    "locales": "Sprachen",
+    "strings": "Strings",
+    "string-index": "Index",
+    "string-content": "String"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -119,5 +119,19 @@
     },
     "LAYER_SETTINGS": {
         "HEADER": "Layers"
+    },
+    "str-parser": {
+        "title": "STR Parser",
+        "short-description": "Parses and displays Thandor .str text resource files containing localized strings.",
+        "select-file": "Select .str file",
+        "start": "Start Parser",
+        "error": {
+            "parse-failed": "Failed to parse the .str file."
+        },
+        "locale-count": "Locale Count",
+        "locales": "Locales",
+        "strings": "strings",
+        "string-index": "Index",
+        "string-content": "String"
     }
 }

--- a/src/conf/AppRoutes.tsx
+++ b/src/conf/AppRoutes.tsx
@@ -9,6 +9,7 @@ const PageEditLevel = lazy(() => import("../pages/edit/level/PageEditLevel"));
 const PagePckExtractor = lazy(() => import("../pages/extract-pck/PagePckExtractor"));
 const PageSamDecoder = lazy(() => import("../pages/sam-decoder/PageSamDecoder"));
 const PageFlmDecoder = lazy(() => import("../pages/flm-decoder/PageFlmDecoder"));
+const PageStrParser = lazy(() => import("../pages/str-parser/PageStrParser"));
 const darkTheme = createTheme({ palette: { mode: "dark" } });
 
 export const PROJECT_URL = "https://github.com/Morodar/InvasionEdit";
@@ -18,6 +19,7 @@ export const EDIT_LVL = "/edit/level";
 export const EXTRACT_PCK = "/extract/pck";
 export const SAM_DECODER = "/patch/sam";
 export const FLM_DECODER = "/patch/flm";
+export const STR_PARSER = "/patch/str";
 
 export const AppRoutes = () => {
     return (
@@ -30,6 +32,7 @@ export const AppRoutes = () => {
                         <Route path={EDIT_LVL} element={<PageEditLevel />} />
                         <Route path={SAM_DECODER} element={<PageSamDecoder />} />
                         <Route path={FLM_DECODER} element={<PageFlmDecoder />} />
+                        <Route path={STR_PARSER} element={<PageStrParser />} />
                         <Route path={HOME} element={<PageHome />} />
                         <Route path="/*" element={<Navigate to={HOME} />} />
                     </Routes>

--- a/src/domain/str/StrFile.ts
+++ b/src/domain/str/StrFile.ts
@@ -1,0 +1,10 @@
+export interface StrLocaleBlock {
+    countryCode: number;
+    reserved: number;
+    strings: string[];
+}
+
+export interface StrFile {
+    localeCount: number;
+    blocks: StrLocaleBlock[];
+}

--- a/src/domain/str/StrUtils.ts
+++ b/src/domain/str/StrUtils.ts
@@ -1,0 +1,148 @@
+import { HeaderUtils } from "../HeaderUtils";
+import { StrFile, StrLocaleBlock } from "./StrFile";
+
+const HEADER_SIZE = 0x200;
+const LOCALE_COUNT_OFFSET = 0xb0;
+const BLOCK_PREFIX_SIZE = 0x10;
+
+const FOURCC_STR = 0x00727473; // fourcc("str") little-endian
+
+export class StrUtils extends HeaderUtils {
+    constructor(dataView: DataView) {
+        super(dataView);
+    }
+
+    static fromArrayBuffer(buffer: ArrayBuffer): StrUtils {
+        return new StrUtils(new DataView(buffer));
+    }
+
+    canReadHeader = (): boolean => this.view.byteLength >= HEADER_SIZE;
+
+    getMagic = (): number => this.getUint32(0);
+
+    getAllocationSize = (): number => this.getUint32(4);
+
+    getLocaleCount = (): number => this.getUint32(LOCALE_COUNT_OFFSET);
+
+    getBlockSize = (offset: number): number => this.getUint32(offset);
+
+    getStringCount = (offset: number): number => this.getUint32(offset + 4);
+
+    getCountryCode = (offset: number): number => this.getUint32(offset + 8);
+
+    getStringOffset = (blockOffset: number, index: number): number =>
+        this.getUint32(blockOffset + BLOCK_PREFIX_SIZE + index * 4);
+
+    readStrString(blockOffset: number, fromByteOffset: number, byteLength: number): string {
+        let result = "";
+        const endOffset = blockOffset + fromByteOffset + byteLength;
+
+        for (let i = blockOffset + fromByteOffset; i < endOffset; i += 2) {
+            const char = this.view.getUint16(i, true);
+            if (char === 0) break;
+            result += String.fromCharCode(char);
+        }
+        return result;
+    }
+
+    parseStrFile = (): StrFile => {
+        if (!this.canReadHeader()) {
+            throw new Error("File too small to be a valid STR file");
+        }
+
+        const magic = this.getMagic();
+        if (magic !== FOURCC_STR) {
+            throw new Error("Invalid STR magic number");
+        }
+
+        const allocationSize = this.getAllocationSize();
+        if (allocationSize !== this.view.byteLength) {
+            throw new Error(
+                `STR allocation size mismatch: expected ${allocationSize}, got ${this.view.byteLength}`
+            );
+        }
+
+        const localeCount = this.getLocaleCount();
+        const blocks: StrLocaleBlock[] = [];
+        let cursor = HEADER_SIZE;
+
+        for (let locale = 0; locale < localeCount; locale++) {
+            if (cursor + BLOCK_PREFIX_SIZE > this.view.byteLength) {
+                throw new Error("STR locale block prefix exceeds file bounds");
+            }
+
+            const blockSize = this.getBlockSize(cursor);
+            const stringCount = this.getStringCount(cursor);
+            const countryCode = this.getCountryCode(cursor);
+
+            if (
+                blockSize < BLOCK_PREFIX_SIZE + stringCount * 4 ||
+                cursor + blockSize > this.view.byteLength ||
+                (blockSize & 3) !== 0
+            ) {
+                throw new Error("STR locale block has invalid size");
+            }
+
+            const offsets: number[] = [];
+            for (let i = 0; i < stringCount; i++) {
+                const offset = this.getStringOffset(cursor, i);
+                const minimum = BLOCK_PREFIX_SIZE + stringCount * 4;
+                if (offset < minimum || offset >= blockSize || (offset & 1) !== 0) {
+                    throw new Error("STR string offset is outside its locale block");
+                }
+                if (offsets.length > 0 && offset < offsets[offsets.length - 1]) {
+                    throw new Error("STR string offsets are not ordered");
+                }
+                offsets.push(offset);
+            }
+            offsets.push(blockSize);
+
+            const strings: string[] = [];
+            for (let i = 0; i < stringCount; i++) {
+                const begin = offsets[i];
+                const end = offsets[i + 1];
+                strings.push(this.readStrString(cursor, begin, end - begin));
+            }
+
+            blocks.push({ countryCode, reserved: 0, strings });
+            cursor += blockSize;
+        }
+
+        if (cursor !== this.view.byteLength) {
+            throw new Error("STR locale-block walk did not end at file boundary");
+        }
+
+        return { localeCount, blocks };
+    };
+}
+
+const selectBlock = (strFile: StrFile, preferredCountry: number): StrLocaleBlock => {
+    if (strFile.blocks.length === 0) {
+        throw new Error("STR file has no locale blocks");
+    }
+    const exact = strFile.blocks.find((b) => b.countryCode === preferredCountry);
+    if (exact) return exact;
+    const english = strFile.blocks.find((b) => b.countryCode === 44);
+    if (english) return english;
+    return strFile.blocks[0];
+};
+
+export const getString = (
+    strFile: StrFile,
+    index: number,
+    preferredCountry: number = 44
+): string => {
+    const block = selectBlock(strFile, preferredCountry);
+    if (index >= block.strings.length) {
+        throw new Error("STR string index exceeds selected locale block");
+    }
+    return block.strings[index];
+};
+
+export const getCountryCodes = (strFile: StrFile): number[] => {
+    return strFile.blocks.map((b) => b.countryCode);
+};
+
+export const getStringCount = (strFile: StrFile, countryCode: number = 44): number => {
+    return selectBlock(strFile, countryCode).strings.length;
+};

--- a/src/pages/home/PageHome.tsx
+++ b/src/pages/home/PageHome.tsx
@@ -8,6 +8,7 @@ import { usePageTitle } from "../../common/utils/usePageTitle";
 import { LevelEditorCard } from "./components/LevelEditorCard";
 import { SamDecoderCard } from "./components/SamDecoderCard";
 import { FlmDecoderCard } from "./components/FlmDecoderCard";
+import { StrParserCard } from "./components/StrParserCard";
 
 const PageHome = () => {
     const { t } = useTranslation();
@@ -42,6 +43,7 @@ const PageHome = () => {
                     <PckExtractorCard />
                     <SamDecoderCard />
                     <FlmDecoderCard />
+                    <StrParserCard />
                 </Stack>
             </Stack>
         </MainLayout>

--- a/src/pages/home/components/StrParserCard.tsx
+++ b/src/pages/home/components/StrParserCard.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from "react-i18next";
+import { STR_PARSER } from "../../../conf/AppRoutes";
+import { HomeCard } from "./HomeCard";
+
+export const StrParserCard = () => {
+    const { t } = useTranslation();
+    return (
+        <HomeCard
+            description={t("str-parser.short-description")}
+            imgUrl="img/extract-str.png"
+            linkDest={STR_PARSER}
+            linkText={t("str-parser.start")}
+            title={t("str-parser.title")}
+        />
+    );
+};

--- a/src/pages/str-parser/PageStrParser.tsx
+++ b/src/pages/str-parser/PageStrParser.tsx
@@ -1,0 +1,55 @@
+import { MainLayout } from "../../layout/MainLayout";
+import { Stack, Typography } from "@mui/material";
+import { useState } from "react";
+import { StrSelectFileCard } from "./components/StrSelectFileCard";
+import { ParseFailedError } from "./components/ParseFailedError";
+import { usePageTitle } from "../../common/utils/usePageTitle";
+import { useTranslation } from "react-i18next";
+import { StrFile } from "../../domain/str/StrFile";
+import { StrUtils } from "../../domain/str/StrUtils";
+import { StrHeaderInfo } from "./components/StrHeaderInfo";
+import { StrLocaleList } from "./components/StrLocaleList";
+
+const PageStrParser = () => {
+    const { t } = useTranslation();
+    const strParser = t("str-parser.title");
+    usePageTitle(strParser);
+
+    const [selectedFile, setSelectedFile] = useState<File>();
+    const [strFile, setStrFile] = useState<StrFile>();
+    const [parseFailed, setParseFailed] = useState(false);
+    const [isParsing, setIsParsing] = useState(false);
+
+    const handleFileChanged = async (file?: File) => {
+        setParseFailed(false);
+        setStrFile(undefined);
+        setSelectedFile(file);
+        if (file && !isParsing) {
+            setIsParsing(true);
+            try {
+                const parsed = StrUtils.fromArrayBuffer(await file.arrayBuffer()).parseStrFile();
+                setStrFile(parsed);
+            } catch {
+                setParseFailed(true);
+            } finally {
+                setIsParsing(false);
+            }
+        }
+    };
+
+    return (
+        <MainLayout mainMaxWidth={900}>
+            <Typography variant="h3" component="h2" display="block" gutterBottom>
+                {strParser}
+            </Typography>
+            <Stack gap="16px">
+                <ParseFailedError failed={parseFailed} />
+                <StrSelectFileCard onFileChanged={handleFileChanged} disableSelection={isParsing} />
+                <StrHeaderInfo strFile={strFile} selectedFile={selectedFile} />
+                {strFile && <StrLocaleList strFile={strFile} />}
+            </Stack>
+        </MainLayout>
+    );
+};
+
+export default PageStrParser;

--- a/src/pages/str-parser/PageStrParser.tsx
+++ b/src/pages/str-parser/PageStrParser.tsx
@@ -39,10 +39,10 @@ const PageStrParser = () => {
 
     return (
         <MainLayout mainMaxWidth={900}>
-            <Typography variant="h3" component="h2" display="block" gutterBottom>
+            <Typography variant="h3" component="h2" sx={{ display: "block" }} gutterBottom>
                 {strParser}
             </Typography>
-            <Stack gap="16px">
+            <Stack sx={{ gap: "16px" }}>
                 <ParseFailedError failed={parseFailed} />
                 <StrSelectFileCard onFileChanged={handleFileChanged} disableSelection={isParsing} />
                 <StrHeaderInfo strFile={strFile} selectedFile={selectedFile} />

--- a/src/pages/str-parser/components/ParseFailedError.tsx
+++ b/src/pages/str-parser/components/ParseFailedError.tsx
@@ -1,0 +1,16 @@
+import { Alert } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+interface ParseFailedErrorProps {
+    failed: boolean;
+}
+
+export const ParseFailedError = ({ failed }: ParseFailedErrorProps) => {
+    const { t } = useTranslation();
+
+    if (!failed) {
+        return <></>;
+    }
+
+    return <Alert severity="warning">{t("str-parser.error.parse-failed")}</Alert>;
+};

--- a/src/pages/str-parser/components/StrHeaderInfo.tsx
+++ b/src/pages/str-parser/components/StrHeaderInfo.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, Stack, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { StrFile } from "../../../domain/str/StrFile";
+
+interface StrHeaderInfoProps {
+    strFile?: StrFile;
+    selectedFile?: File;
+}
+
+const COUNTRY_NAMES: Record<number, string> = {
+    44: "English",
+    49: "German",
+    1: "Japanese",
+};
+
+export const StrHeaderInfo = (props: StrHeaderInfoProps) => {
+    const { strFile, selectedFile } = props;
+    const { t } = useTranslation();
+
+    if (!strFile && !selectedFile) {
+        return <></>;
+    }
+
+    return (
+        <Card>
+            <CardContent>
+                <Typography variant="h5" gutterBottom>
+                    {t("str-parser.title")}
+                </Typography>
+                <ul>
+                    {selectedFile && <li>Name: {selectedFile.name}</li>}
+                    {strFile && (
+                        <>
+                            <li>
+                                {t("str-parser.locale-count")}: {strFile.localeCount}
+                            </li>
+                            <li>
+                                {t("str-parser.locales")}:
+                                <Stack component="ul" direction="row" spacing={1}>
+                                    {strFile.blocks.map((block) => (
+                                        <li key={block.countryCode}>
+                                            {COUNTRY_NAMES[block.countryCode] || `Code ${block.countryCode}`} ({block.strings.length}{" "}
+                                            {t("str-parser.strings")})
+                                        </li>
+                                    ))}
+                                </Stack>
+                            </li>
+                        </>
+                    )}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/pages/str-parser/components/StrHeaderInfo.tsx
+++ b/src/pages/str-parser/components/StrHeaderInfo.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Stack, Typography } from "@mui/material";
+import { Card, CardContent, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { StrFile } from "../../../domain/str/StrFile";
 
@@ -8,6 +8,9 @@ interface StrHeaderInfoProps {
 }
 
 const COUNTRY_NAMES: Record<number, string> = {
+    39: "Italian",
+    34: "Spanish",
+    33: "French",
     44: "English",
     49: "German",
     1: "Japanese",
@@ -36,14 +39,14 @@ export const StrHeaderInfo = (props: StrHeaderInfoProps) => {
                             </li>
                             <li>
                                 {t("str-parser.locales")}:
-                                <Stack component="ul" direction="row" spacing={1}>
+                                <ul>
                                     {strFile.blocks.map((block) => (
                                         <li key={block.countryCode}>
-                                            {COUNTRY_NAMES[block.countryCode] || `Code ${block.countryCode}`} ({block.strings.length}{" "}
-                                            {t("str-parser.strings")})
+                                            {COUNTRY_NAMES[block.countryCode] || `Code ${block.countryCode}`} (
+                                            {block.strings.length} {t("str-parser.strings")})
                                         </li>
                                     ))}
-                                </Stack>
+                                </ul>
                             </li>
                         </>
                     )}

--- a/src/pages/str-parser/components/StrLocaleList.tsx
+++ b/src/pages/str-parser/components/StrLocaleList.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Card, CardContent, Tab, Tabs } from "@mui/material";
+import { StrFile } from "../../../domain/str/StrFile";
+import { StrStringTable } from "./StrStringTable";
+
+const COUNTRY_NAMES: Record<number, string> = {
+    44: "English",
+    49: "German",
+    1: "Japanese",
+};
+
+interface StrLocaleListProps {
+    strFile: StrFile;
+}
+
+export const StrLocaleList = (props: StrLocaleListProps) => {
+    const { strFile } = props;
+    const [selectedLocale, setSelectedLocale] = useState(0);
+
+    if (strFile.blocks.length === 0) {
+        return <></>;
+    }
+
+    return (
+        <Card>
+            <CardContent>
+                <Tabs
+                    value={selectedLocale}
+                    onChange={(_, newValue) => setSelectedLocale(newValue)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                >
+                    {strFile.blocks.map((block) => (
+                        <Tab
+                            key={block.countryCode}
+                            label={`${COUNTRY_NAMES[block.countryCode] || `Code ${block.countryCode}`} (${block.strings.length})`}
+                        />
+                    ))}
+                </Tabs>
+                {strFile.blocks[selectedLocale] && (
+                    <StrStringTable block={strFile.blocks[selectedLocale]} />
+                )}
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/pages/str-parser/components/StrSelectFileCard.tsx
+++ b/src/pages/str-parser/components/StrSelectFileCard.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next";
+import { SelectFileButton } from "../../../common/input/SelectFileButton";
+import { Card, CardContent, Stack } from "@mui/material";
+
+interface StrSelectFileCardProps {
+    onFileChanged: (file?: File) => void;
+    disableSelection: boolean;
+}
+
+export const StrSelectFileCard = (props: StrSelectFileCardProps) => {
+    const { t } = useTranslation();
+    const { onFileChanged, disableSelection } = props;
+    return (
+        <Card>
+            <CardContent>
+                <p>{t("str-parser.short-description")}</p>
+                <Stack direction="row" justifyContent="end">
+                    <SelectFileButton onFileChanged={onFileChanged} accept=".str" disabled={disableSelection}>
+                        {t("str-parser.select-file")}
+                    </SelectFileButton>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/pages/str-parser/components/StrSelectFileCard.tsx
+++ b/src/pages/str-parser/components/StrSelectFileCard.tsx
@@ -14,7 +14,7 @@ export const StrSelectFileCard = (props: StrSelectFileCardProps) => {
         <Card>
             <CardContent>
                 <p>{t("str-parser.short-description")}</p>
-                <Stack direction="row" justifyContent="end">
+                <Stack direction="row" sx={{ justifyContent: "end" }}>
                     <SelectFileButton onFileChanged={onFileChanged} accept=".str" disabled={disableSelection}>
                         {t("str-parser.select-file")}
                     </SelectFileButton>

--- a/src/pages/str-parser/components/StrStringTable.tsx
+++ b/src/pages/str-parser/components/StrStringTable.tsx
@@ -1,0 +1,35 @@
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { StrLocaleBlock } from "../../../domain/str/StrFile";
+
+interface StrStringTableProps {
+    block: StrLocaleBlock;
+}
+
+export const StrStringTable = (props: StrStringTableProps) => {
+    const { block } = props;
+    const { t } = useTranslation();
+
+    return (
+        <TableContainer component={Paper} sx={{ mt: 2, maxHeight: 600 }}>
+            <Table size="small" stickyHeader>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>{t("str-parser.string-index")}</TableCell>
+                        <TableCell>{t("str-parser.string-content")}</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {block.strings.map((str, index) => (
+                        <TableRow key={index}>
+                            <TableCell>{index}</TableCell>
+                            <TableCell sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                                {str}
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+};

--- a/test/domain/str/StrUtils.test.ts
+++ b/test/domain/str/StrUtils.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { StrUtils, getString, getCountryCodes, getStringCount } from "../../../src/domain/str/StrUtils";
+
+const STR_MAGIC = 0x00727473; // fourcc("str")
+
+const buildMinimalStr = (): ArrayBuffer => {
+    const buffer = new ArrayBuffer(0x220);
+    const view = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    view.setUint32(0, STR_MAGIC, true);
+    view.setUint32(4, 0x220, true);
+    view.setUint32(0xb0, 1, true);
+
+    const b = 0x200;
+    view.setUint32(b + 0x00, 0x20, true);
+    view.setUint32(b + 0x04, 1, true);
+    view.setUint32(b + 0x08, 44, true);
+    view.setUint32(b + 0x0c, 0, true);
+    view.setUint32(b + 0x10, 0x14, true);
+
+    const hello = [0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f, 0x00, 0x00, 0x00];
+    for (let i = 0; i < hello.length; i++) bytes[b + 0x14 + i] = hello[i];
+
+    return buffer;
+};
+
+const buildMultiLocaleStr = (): ArrayBuffer => {
+    const buffer = new ArrayBuffer(0x240);
+    const view = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    view.setUint32(0, STR_MAGIC, true);
+    view.setUint32(4, 0x240, true);
+    view.setUint32(0xb0, 2, true);
+
+    let b = 0x200;
+    view.setUint32(b + 0x00, 0x20, true);
+    view.setUint32(b + 0x04, 1, true);
+    view.setUint32(b + 0x08, 44, true);
+    view.setUint32(b + 0x0c, 0, true);
+    view.setUint32(b + 0x10, 0x14, true);
+    const strA = [0x41, 0x00, 0x00, 0x00, 0x00, 0x00];
+    for (let i = 0; i < strA.length; i++) bytes[b + 0x14 + i] = strA[i];
+
+    b = 0x220;
+    view.setUint32(b + 0x00, 0x20, true);
+    view.setUint32(b + 0x04, 1, true);
+    view.setUint32(b + 0x08, 49, true);
+    view.setUint32(b + 0x0c, 0, true);
+    view.setUint32(b + 0x10, 0x14, true);
+    const strB = [0x42, 0x00, 0x00, 0x00, 0x00, 0x00];
+    for (let i = 0; i < strB.length; i++) bytes[b + 0x14 + i] = strB[i];
+
+    return buffer;
+};
+
+describe("StrUtils", () => {
+    describe("parseStrFile", () => {
+        it("parses a minimal single-locale STR file", () => {
+            const result = StrUtils.fromArrayBuffer(buildMinimalStr()).parseStrFile();
+
+            expect(result.localeCount).toBe(1);
+            expect(result.blocks).toHaveLength(1);
+            expect(result.blocks[0].countryCode).toBe(44);
+            expect(result.blocks[0].strings).toHaveLength(1);
+            expect(result.blocks[0].strings[0]).toBe("Hello");
+        });
+
+        it("parses a multi-locale STR file", () => {
+            const result = StrUtils.fromArrayBuffer(buildMultiLocaleStr()).parseStrFile();
+
+            expect(result.localeCount).toBe(2);
+            expect(result.blocks).toHaveLength(2);
+            expect(result.blocks[0].countryCode).toBe(44);
+            expect(result.blocks[0].strings[0]).toBe("A");
+            expect(result.blocks[1].countryCode).toBe(49);
+            expect(result.blocks[1].strings[0]).toBe("B");
+        });
+
+        it("rejects files smaller than header", () => {
+            const bytes = new ArrayBuffer(10);
+            expect(() => StrUtils.fromArrayBuffer(bytes).parseStrFile()).toThrow("too small");
+        });
+
+        it("rejects invalid magic", () => {
+            const bytes = new ArrayBuffer(0x200);
+            const view = new DataView(bytes);
+            view.setUint32(0, 0xdeadbeef, true);
+            view.setUint32(4, 0x200, true);
+            expect(() => StrUtils.fromArrayBuffer(bytes).parseStrFile()).toThrow("Invalid STR magic");
+        });
+
+        it("rejects allocation size mismatch", () => {
+            const bytes = new ArrayBuffer(0x200);
+            const view = new DataView(bytes);
+            view.setUint32(0, STR_MAGIC, true);
+            view.setUint32(4, 0x100, true);
+            expect(() => StrUtils.fromArrayBuffer(bytes).parseStrFile()).toThrow("allocation size mismatch");
+        });
+    });
+
+    describe("getString", () => {
+        it("returns the correct string by index", () => {
+            const str = StrUtils.fromArrayBuffer(buildMinimalStr()).parseStrFile();
+            expect(getString(str, 0)).toBe("Hello");
+        });
+
+        it("throws for out-of-bounds index", () => {
+            const str = StrUtils.fromArrayBuffer(buildMinimalStr()).parseStrFile();
+            expect(() => getString(str, 99)).toThrow("exceeds");
+        });
+
+        it("falls back to English when preferred locale not found", () => {
+            const str = StrUtils.fromArrayBuffer(buildMultiLocaleStr()).parseStrFile();
+            expect(getString(str, 0, 999)).toBe("A");
+        });
+    });
+
+    describe("getCountryCodes", () => {
+        it("returns all country codes", () => {
+            const str = StrUtils.fromArrayBuffer(buildMultiLocaleStr()).parseStrFile();
+            expect(getCountryCodes(str)).toEqual([44, 49]);
+        });
+    });
+
+    describe("getStringCount", () => {
+        it("returns count for a specific locale", () => {
+            const str = StrUtils.fromArrayBuffer(buildMultiLocaleStr()).parseStrFile();
+            expect(getStringCount(str, 44)).toBe(1);
+            expect(getStringCount(str, 49)).toBe(1);
+        });
+
+        it("defaults to English (44)", () => {
+            const str = StrUtils.fromArrayBuffer(buildMultiLocaleStr()).parseStrFile();
+            expect(getStringCount(str)).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
Port parser from thandor-map-editor C++ project to parse and display .localised .str text resource files from Invasion/Thandor.

Includes:
- StrFile types and StrUtils parser with full binary format support
- Parser page with file selection, header info, and locale tabs
- Unit tests (11/11 passing)
- Route, home card, and i18n keys (en + de-DE)

Closes #16