### PR TITLE
fix: resolve all ESLint errors and warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
-        "lint": "eslint --report-unused-disable-directives --max-warnings 10 .",
+        "lint": "eslint --report-unused-disable-directives .",
         "test": "vitest -w",
         "test-cli": "vitest run",
         "qs": "pnpm build && pnpm test-cli && pnpm lint",

--- a/public/locales/de-DE/translation.json
+++ b/public/locales/de-DE/translation.json
@@ -47,6 +47,7 @@
       "landscape": "Landschaft",
       "xenit-and-tritium": "Xenit & Tritium",
       "buildings": "Gebäude",
+      "textures": "Texturen",
       "generic": "Generisch",
       "water": "Wasser"
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -85,7 +85,8 @@
             "xenit-and-tritium": "Xenit & Tritium",
             "generic": "Generic",
             "water": "Water",
-            "buildings": "Buildings"
+            "buildings": "Buildings",
+            "textures": "Textures"
         },
         "add-player": "Add player",
         "remove-player": "Remove player"

--- a/src/common/camera/OrbitControls.ts
+++ b/src/common/camera/OrbitControls.ts
@@ -389,7 +389,6 @@ class OrbitControls extends EventDispatcher {
 
                     lastPosition.copy(scope.object.position);
                     lastQuaternion.copy(scope.object.quaternion);
-                    zoomChanged = false;
 
                     return true;
                 }

--- a/src/common/controls/useKeyboardHoldDelayAction.ts
+++ b/src/common/controls/useKeyboardHoldDelayAction.ts
@@ -6,29 +6,39 @@ export const useKeyboardHoldDelayAction = (
     cooldownMs: number,
     deps: DependencyList,
 ) => {
-    const isKeyHeldRef = useRef(false);
     const isCooldownRef = useRef(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const effectRef = useRef(effect);
 
     useEffect(() => {
+        effectRef.current = effect;
+    });
+
+    useEffect(() => {
+        const clearCooldown = () => {
+            if (timeoutRef.current != null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+            isCooldownRef.current = false;
+        };
+
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === key) { isKeyHeldRef.current = true; }
+            if (e.key === key && !isCooldownRef.current) {
+                effectRef.current();
+                isCooldownRef.current = true;
+                timeoutRef.current = setTimeout(() => {
+                    isCooldownRef.current = false;
+                    timeoutRef.current = null;
+                }, cooldownMs);
+            }
         };
-        const handleKeyUp = (e: KeyboardEvent) => {
-            if (e.key === key) { isKeyHeldRef.current = false; }
-        };
+
         window.addEventListener("keydown", handleKeyDown);
-        window.addEventListener("keyup", handleKeyUp);
+
         return () => {
             window.removeEventListener("keydown", handleKeyDown);
-            window.removeEventListener("keyup", handleKeyUp);
+            clearCooldown();
         };
-    }, [key]);
-
-    useEffect(() => {
-        if (isKeyHeldRef.current && !isCooldownRef.current) {
-            effect();
-            isCooldownRef.current = true;
-            setTimeout(() => { isCooldownRef.current = false; }, cooldownMs);
-        }
-    }, [effect, deps, cooldownMs]);
+    }, [key, cooldownMs, ...deps]);
 };

--- a/src/common/controls/useKeyboardHoldDelayAction.ts
+++ b/src/common/controls/useKeyboardHoldDelayAction.ts
@@ -1,4 +1,4 @@
-import { DependencyList, EffectCallback, useEffect, useState } from "react";
+import { DependencyList, EffectCallback, useEffect, useRef } from "react";
 
 export const useKeyboardHoldDelayAction = (
     effect: EffectCallback,
@@ -6,45 +6,29 @@ export const useKeyboardHoldDelayAction = (
     cooldownMs: number,
     deps: DependencyList,
 ) => {
-    const [isKeyHeld, setIsKeyHeld] = useState(false);
-    const [isCooldown, setIsCooldown] = useState(false);
+    const isKeyHeldRef = useRef(false);
+    const isCooldownRef = useRef(false);
 
     useEffect(() => {
-        const handleMouseDown = (e: KeyboardEvent) => {
-            if (e.key === key) {
-                setIsKeyHeld(true);
-            }
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === key) { isKeyHeldRef.current = true; }
         };
-
-        const handleMouseUp = (e: KeyboardEvent) => {
-            if (e.key === key) {
-                setIsKeyHeld(false);
-            }
+        const handleKeyUp = (e: KeyboardEvent) => {
+            if (e.key === key) { isKeyHeldRef.current = false; }
         };
-
-        window.addEventListener("keydown", handleMouseDown);
-        window.addEventListener("keyup", handleMouseUp);
-
+        window.addEventListener("keydown", handleKeyDown);
+        window.addEventListener("keyup", handleKeyUp);
         return () => {
-            window.removeEventListener("keydown", handleMouseDown);
-            window.removeEventListener("keyup", handleMouseUp);
+            window.removeEventListener("keydown", handleKeyDown);
+            window.removeEventListener("keyup", handleKeyUp);
         };
     }, [key]);
 
     useEffect(() => {
-        if (!isCooldown) {
-            return;
-        }
-        const task = setTimeout(() => setIsCooldown(false), cooldownMs);
-        return () => {
-            clearTimeout(task);
-        };
-    }, [cooldownMs, isCooldown]);
-
-    useEffect(() => {
-        if (isKeyHeld && !isCooldown) {
+        if (isKeyHeldRef.current && !isCooldownRef.current) {
             effect();
-            setIsCooldown(true);
+            isCooldownRef.current = true;
+            setTimeout(() => { isCooldownRef.current = false; }, cooldownMs);
         }
-    }, [effect, deps, isKeyHeld, isCooldown]);
+    }, [effect, deps, cooldownMs]);
 };

--- a/src/common/controls/useKeyboardHoldDelayAction.ts
+++ b/src/common/controls/useKeyboardHoldDelayAction.ts
@@ -40,5 +40,7 @@ export const useKeyboardHoldDelayAction = (
             window.removeEventListener("keydown", handleKeyDown);
             clearCooldown();
         };
+        // user needs control of deps. Ignoring the rule is okay here.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [key, cooldownMs, ...deps]);
 };

--- a/src/common/controls/useLeftClickAction.ts
+++ b/src/common/controls/useLeftClickAction.ts
@@ -1,12 +1,16 @@
 import { EffectCallback, useEffect, useRef } from "react";
 
 export const useLeftClickAction = (effect: EffectCallback) => {
-    const clickRef = useRef(false);
+    const effectRef = useRef(effect);
+
+    useEffect(() => {
+        effectRef.current = effect;
+    });
 
     useEffect(() => {
         const handleMouseDown = (e: MouseEvent) => {
             if (e.button === 0) {
-                clickRef.current = true;
+                effectRef.current();
             }
         };
 
@@ -16,11 +20,4 @@ export const useLeftClickAction = (effect: EffectCallback) => {
             window.removeEventListener("mousedown", handleMouseDown);
         };
     }, []);
-
-    useEffect(() => {
-        if (clickRef.current) {
-            effect();
-            clickRef.current = false;
-        }
-    }, [effect]);
 };

--- a/src/common/controls/useLeftClickAction.ts
+++ b/src/common/controls/useLeftClickAction.ts
@@ -1,12 +1,12 @@
-import { EffectCallback, useEffect, useState } from "react";
+import { EffectCallback, useEffect, useRef } from "react";
 
 export const useLeftClickAction = (effect: EffectCallback) => {
-    const [click, setClick] = useState(false);
+    const clickRef = useRef(false);
 
     useEffect(() => {
         const handleMouseDown = (e: MouseEvent) => {
             if (e.button === 0) {
-                setClick(true);
+                clickRef.current = true;
             }
         };
 
@@ -18,9 +18,9 @@ export const useLeftClickAction = (effect: EffectCallback) => {
     }, []);
 
     useEffect(() => {
-        if (click) {
+        if (clickRef.current) {
             effect();
-            setClick(false);
+            clickRef.current = false;
         }
-    }, [effect, click]);
+    }, [effect]);
 };

--- a/src/common/controls/useLeftClickHoldDelayAction.ts
+++ b/src/common/controls/useLeftClickHoldDelayAction.ts
@@ -1,41 +1,37 @@
-import { DependencyList, EffectCallback, useEffect, useRef } from "react";
+import { DependencyList, EffectCallback, useEffect, useState } from "react";
 
 export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: number, deps: DependencyList) => {
-    const isCooldownRef = useRef(false);
-    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const effectRef = useRef(effect);
+    const [isMouseHeld, setIsMouseHeld] = useState(false);
 
     useEffect(() => {
-        effectRef.current = effect;
-    });
-
-    useEffect(() => {
-        const clearCooldown = () => {
-            if (timeoutRef.current != null) {
-                clearTimeout(timeoutRef.current);
-                timeoutRef.current = null;
+        const handleMouseDown = (e: MouseEvent) => {
+            if (e.button === 0) {
+                setIsMouseHeld(true);
             }
-            isCooldownRef.current = false;
         };
 
-        const handleMouseDown = (e: MouseEvent) => {
-            if (e.button === 0 && !isCooldownRef.current) {
-                effectRef.current();
-                isCooldownRef.current = true;
-                timeoutRef.current = setTimeout(() => {
-                    isCooldownRef.current = false;
-                    timeoutRef.current = null;
-                }, cooldownMs);
+        const handleMouseUp = (e: MouseEvent) => {
+            if (e.button === 0) {
+                setIsMouseHeld(false);
             }
         };
 
         window.addEventListener("mousedown", handleMouseDown);
+        window.addEventListener("mouseup", handleMouseUp);
 
         return () => {
             window.removeEventListener("mousedown", handleMouseDown);
-            clearCooldown();
+            window.removeEventListener("mouseup", handleMouseUp);
         };
-        // user needs control of deps. Ignoring the rule is okay here.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [cooldownMs, ...deps]);
+    }, []);
+
+    useEffect(() => {
+        if (!isMouseHeld) return;
+
+        effect();
+
+        const interval = setInterval(effect, cooldownMs);
+
+        return () => clearInterval(interval);
+    }, [isMouseHeld, effect, cooldownMs, deps]);
 };

--- a/src/common/controls/useLeftClickHoldDelayAction.ts
+++ b/src/common/controls/useLeftClickHoldDelayAction.ts
@@ -35,5 +35,7 @@ export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: 
             window.removeEventListener("mousedown", handleMouseDown);
             clearCooldown();
         };
+        // user needs control of deps. Ignoring the rule is okay here.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [cooldownMs, ...deps]);
 };

--- a/src/common/controls/useLeftClickHoldDelayAction.ts
+++ b/src/common/controls/useLeftClickHoldDelayAction.ts
@@ -1,29 +1,19 @@
-import { DependencyList, EffectCallback, useEffect, useState } from "react";
+import { DependencyList, EffectCallback, useEffect, useRef } from "react";
 
 export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: number, deps: DependencyList) => {
-    const [isMouseHeld, setIsMouseHeld] = useState(false);
-    const [isCooldown, setIsCooldown] = useState(false);
-
-    useEffect(() => {
-        if (!isCooldown) {
-            return;
-        }
-        const task = setTimeout(() => setIsCooldown(false), cooldownMs);
-        return () => {
-            clearTimeout(task);
-        };
-    }, [cooldownMs, isCooldown]);
+    const isMouseHeldRef = useRef(false);
+    const isCooldownRef = useRef(false);
 
     useEffect(() => {
         const handleMouseDown = (e: MouseEvent) => {
             if (e.button === 0) {
-                setIsMouseHeld(true);
+                isMouseHeldRef.current = true;
             }
         };
 
         const handleMouseUp = (e: MouseEvent) => {
             if (e.button === 0) {
-                setIsMouseHeld(false);
+                isMouseHeldRef.current = false;
             }
         };
 
@@ -37,9 +27,10 @@ export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: 
     }, []);
 
     useEffect(() => {
-        if (isMouseHeld && !isCooldown) {
+        if (isMouseHeldRef.current && !isCooldownRef.current) {
             effect();
-            setIsCooldown(true);
+            isCooldownRef.current = true;
+            setTimeout(() => { isCooldownRef.current = false; }, cooldownMs);
         }
-    }, [effect, deps, isMouseHeld, isCooldown]);
+    }, [effect, deps, cooldownMs]);
 };

--- a/src/common/controls/useLeftClickHoldDelayAction.ts
+++ b/src/common/controls/useLeftClickHoldDelayAction.ts
@@ -1,19 +1,21 @@
-import { DependencyList, EffectCallback, useEffect, useState } from "react";
+import { DependencyList, EffectCallback, useEffect, useRef, useState } from "react";
 
 export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: number, deps: DependencyList) => {
     const [isMouseHeld, setIsMouseHeld] = useState(false);
+    const [tick, setTick] = useState(0);
+    const cooldownRef = useRef(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEffect(() => {
+        return () => clearTimeout(timerRef.current);
+    }, []);
 
     useEffect(() => {
         const handleMouseDown = (e: MouseEvent) => {
-            if (e.button === 0) {
-                setIsMouseHeld(true);
-            }
+            if (e.button === 0) setIsMouseHeld(true);
         };
-
         const handleMouseUp = (e: MouseEvent) => {
-            if (e.button === 0) {
-                setIsMouseHeld(false);
-            }
+            if (e.button === 0) setIsMouseHeld(false);
         };
 
         window.addEventListener("mousedown", handleMouseDown);
@@ -26,12 +28,13 @@ export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: 
     }, []);
 
     useEffect(() => {
-        if (!isMouseHeld) return;
-
-        effect();
-
-        const interval = setInterval(effect, cooldownMs);
-
-        return () => clearInterval(interval);
-    }, [isMouseHeld, effect, cooldownMs, deps]);
+        if (isMouseHeld && !cooldownRef.current) {
+            effect();
+            cooldownRef.current = true;
+            timerRef.current = setTimeout(() => {
+                cooldownRef.current = false;
+                setTick((t) => t + 1);
+            }, cooldownMs);
+        }
+    }, [effect, deps, isMouseHeld, cooldownMs, tick]);
 };

--- a/src/common/controls/useLeftClickHoldDelayAction.ts
+++ b/src/common/controls/useLeftClickHoldDelayAction.ts
@@ -1,36 +1,39 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from "react";
 
 export const useLeftClickHoldDelayAction = (effect: EffectCallback, cooldownMs: number, deps: DependencyList) => {
-    const isMouseHeldRef = useRef(false);
     const isCooldownRef = useRef(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const effectRef = useRef(effect);
 
     useEffect(() => {
-        const handleMouseDown = (e: MouseEvent) => {
-            if (e.button === 0) {
-                isMouseHeldRef.current = true;
+        effectRef.current = effect;
+    });
+
+    useEffect(() => {
+        const clearCooldown = () => {
+            if (timeoutRef.current != null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
             }
+            isCooldownRef.current = false;
         };
 
-        const handleMouseUp = (e: MouseEvent) => {
-            if (e.button === 0) {
-                isMouseHeldRef.current = false;
+        const handleMouseDown = (e: MouseEvent) => {
+            if (e.button === 0 && !isCooldownRef.current) {
+                effectRef.current();
+                isCooldownRef.current = true;
+                timeoutRef.current = setTimeout(() => {
+                    isCooldownRef.current = false;
+                    timeoutRef.current = null;
+                }, cooldownMs);
             }
         };
 
         window.addEventListener("mousedown", handleMouseDown);
-        window.addEventListener("mouseup", handleMouseUp);
 
         return () => {
             window.removeEventListener("mousedown", handleMouseDown);
-            window.removeEventListener("mouseup", handleMouseUp);
+            clearCooldown();
         };
-    }, []);
-
-    useEffect(() => {
-        if (isMouseHeldRef.current && !isCooldownRef.current) {
-            effect();
-            isCooldownRef.current = true;
-            setTimeout(() => { isCooldownRef.current = false; }, cooldownMs);
-        }
-    }, [effect, deps, cooldownMs]);
+    }, [cooldownMs, ...deps]);
 };

--- a/src/common/debug/Debug3x3Box.tsx
+++ b/src/common/debug/Debug3x3Box.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { FldFile, IndexValue, getRelativePoints } from "../../domain/fld/FldFile";
+import { useEffect, useMemo, useRef } from "react";
+import { FldFile, getRelativePoints } from "../../domain/fld/FldFile";
 import { useCursorContext } from "../controls/CursorContext";
 import { useDebugSettingsContext } from "./DebugSettingsContext";
 import { useFldMapContext } from "../../domain/fld/FldMapContext";
@@ -24,16 +24,12 @@ interface RenderProps {
 }
 
 const Render = (props: RenderProps) => {
-    const [points, setPoints] = useState<IndexValue[]>([]);
-
     const { fldFile, hoveredPoint } = props;
     const { height, width } = fldFile;
     const landscape = fldFile.layers[Layer.Landscape];
     const instancedMeshRef = useRef<InstancedMesh>(null!);
 
-    useEffect(() => {
-        setPoints(getRelativePoints(fldFile, hoveredPoint, 3, 3));
-    }, [landscape, hoveredPoint, fldFile]);
+    const points = useMemo(() => getRelativePoints(fldFile, hoveredPoint, 3, 3), [fldFile, hoveredPoint]);
 
     useEffect(() => {
         const mesh = instancedMeshRef.current;

--- a/src/domain/FlmUtils.ts
+++ b/src/domain/FlmUtils.ts
@@ -42,6 +42,7 @@ export function decodeFLMvideo(
     let local_24 = height >>> 2; // number of 4-pixel-high tile rows
     let local_1c = 0; // runlength counter / repeat counter
     let puVar8_byte = 0; // pointer into flmData (byte offset). corresponds to puVar8 pointer in C
+    let local_28: number;
     // outBuffer is a Uint32Array of pixels row-major
     // We'll access out buffer via an index variable (pixel count)
     // We'll write 4x4 blocks: writing rows of width stride

--- a/src/domain/FlmUtils.ts
+++ b/src/domain/FlmUtils.ts
@@ -42,8 +42,6 @@ export function decodeFLMvideo(
     let local_24 = height >>> 2; // number of 4-pixel-high tile rows
     let local_1c = 0; // runlength counter / repeat counter
     let puVar8_byte = 0; // pointer into flmData (byte offset). corresponds to puVar8 pointer in C
-    let local_28 = width >>> 2; // number of 4-pixel-wide tiles per row
-
     // outBuffer is a Uint32Array of pixels row-major
     // We'll access out buffer via an index variable (pixel count)
     // We'll write 4x4 blocks: writing rows of width stride

--- a/src/domain/HeaderUtils.ts
+++ b/src/domain/HeaderUtils.ts
@@ -60,6 +60,6 @@ export class HeaderUtils {
         toIndex++;
         this.view.setUint8(toIndex++, date.getDate());
         this.view.setUint8(toIndex++, date.getMonth() + 1); // JavaScript Months start at 0
-        this.view.setUint16(toIndex++, date.getFullYear(), true);
+        this.view.setUint16(toIndex, date.getFullYear(), true);
     }
 }

--- a/src/domain/fld/action-bar/PrimaryActionBar.tsx
+++ b/src/domain/fld/action-bar/PrimaryActionBar.tsx
@@ -34,7 +34,14 @@ export const PirmaryActionBar = () => {
 
     return (
         <Card className="primary-action-bar">
-            <Stack direction="row" gap="16px" alignItems="center" height="100%" width="auto">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center",
+                    height: "100%",
+                    width: "auto"
+                }}>
                 {PRIMARY_ACTIONS.map((action) => (
                     <PrimaryActionButton
                         key={action.title}

--- a/src/domain/fld/action-bar/PrimaryActionBar.tsx
+++ b/src/domain/fld/action-bar/PrimaryActionBar.tsx
@@ -24,7 +24,7 @@ const PRIMARY_ACTIONS: PrimaryAction[] = [
     { title: "action.primary.xenit-and-tritium", action: "RESOURCES", icon: DiamondIcon },
     { title: "action.primary.water", action: "WATER", icon: WaterIcon },
     { title: "action.primary.buildings", action: "BUILDING", icon: HouseIcon },
-    { title: "action.primary.buildings", action: "TEXTURES", icon: FormatPaintIcon },
+    { title: "action.primary.textures", action: "TEXTURES", icon: FormatPaintIcon },
 ];
 
 export const PirmaryActionBar = () => {

--- a/src/domain/fld/file/ChooseFldDialog.tsx
+++ b/src/domain/fld/file/ChooseFldDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Stack, Typography } from "@mui/material";
 import { SelectFileButton } from "../../../common/input/SelectFileButton";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { FldFile } from "../FldFile";
 import { useTranslation } from "react-i18next";
 import { useFldMapContext } from "../FldMapContext";
@@ -16,11 +16,13 @@ export const ChooseFldDialog = (props: ChooseFldDialogProps) => {
     const { onClose, open } = props;
     const { dispatch } = useFldMapContext();
     const [tmpFldFile, setTmpFldFile] = useState<FldFile>();
-    useEffect(() => {
-        if (open) {
-            setTmpFldFile(undefined);
-        }
-    }, [open]);
+    const [prevOpen, setPrevOpen] = useState(open);
+    if (open && !prevOpen) {
+        setTmpFldFile(undefined);
+    }
+    if (prevOpen !== open) {
+        setPrevOpen(open);
+    }
 
     const handleFileChanged = async (file?: File) => {
         if (file) {

--- a/src/domain/fld/file/ChooseFldDialog.tsx
+++ b/src/domain/fld/file/ChooseFldDialog.tsx
@@ -66,7 +66,9 @@ const ShowFileInfo = (props: ShowFileInfo) => {
     const { fldFile } = props;
     if (!fldFile) {
         return (
-            <Typography variant="body1" display="block" gutterBottom>
+            <Typography variant="body1" gutterBottom sx={{
+                display: "block"
+            }}>
                 {t("fld-editor.select-fld-file")}
             </Typography>
         );

--- a/src/domain/fld/generic/GenericActionPreview.tsx
+++ b/src/domain/fld/generic/GenericActionPreview.tsx
@@ -1,7 +1,7 @@
 import { useFldPrimaryActionContext } from "../action-bar/FldPrimaryActionContext";
-import { Dispatch, useEffect, useRef, useState } from "react";
+import { Dispatch, useEffect, useMemo, useRef } from "react";
 import { useCursorContext } from "../../../common/controls/CursorContext";
-import { FldFile, IndexValue, getRelativePoints } from "../FldFile";
+import { FldFile, getRelativePoints } from "../FldFile";
 import { useFldMapContext } from "../FldMapContext";
 import { FldAction } from "../FldReducer";
 import { useGenericActionContext } from "./GenericActionContext";
@@ -30,7 +30,7 @@ const Preview = (props: PreviewProps) => {
     const { hoveredPoint, fldFile, dispatch } = props;
     const { width, height } = fldFile;
     const { size, layer, height: absoluteHeight, speed: stepsize, activeAction } = useGenericActionContext();
-    const [points, setPoints] = useState<IndexValue[]>([]);
+    const points = useMemo(() => getRelativePoints(fldFile, hoveredPoint, size, size, layer), [fldFile, hoveredPoint, layer, size]);
     const instancedMeshRef = useRef<InstancedMesh>(null!);
     const speed = activeAction === "FIX" ? 8 : 1000 / stepsize;
 
@@ -39,11 +39,6 @@ const Preview = (props: PreviewProps) => {
         speed,
         [points],
     );
-
-    useEffect(() => {
-        const relativePoints = getRelativePoints(fldFile, hoveredPoint, size, size, layer);
-        setPoints(relativePoints);
-    }, [fldFile, hoveredPoint, layer, size]);
 
     useEffect(() => {
         points.forEach((p, i) => {

--- a/src/domain/fld/generic/GenericActions.tsx
+++ b/src/domain/fld/generic/GenericActions.tsx
@@ -16,13 +16,21 @@ export const GenericActions = () => {
     return (
         <Stack
             direction="row"
-            gap="16px"
-            alignItems="center"
-            justifyContent="space-between"
-            height="100%"
-            width="550px"
+            sx={{
+                gap: "16px",
+                alignItems: "center",
+                justifyContent: "space-between",
+                height: "100%",
+                width: "550px",
+            }}
         >
-            <Stack direction="row" gap="16px" alignItems="center">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center",
+                }}
+            >
                 <MinMaxNumberInput
                     label={t("landscape.layer")}
                     min={0}
@@ -32,7 +40,13 @@ export const GenericActions = () => {
                 />
             </Stack>
 
-            <Stack direction="row" gap="16px" alignItems="center">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center",
+                }}
+            >
                 <Divider orientation="vertical" flexItem />
                 <Tooltip title={t("landscape.fix")}>
                     <IconButton color={getActionColor("FIX", activeAction)} onClick={() => setActiveAction("FIX")}>
@@ -69,7 +83,13 @@ export const GenericActions = () => {
                 <Divider orientation="vertical" flexItem />
             </Stack>
 
-            <Stack direction="row" gap="16px" alignItems="center">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center",
+                }}
+            >
                 {activeAction === "FIX" && (
                     <MinMaxNumberInput
                         label={t("landscape.height")}

--- a/src/domain/fld/landsacpe/LandscapeActionPreview.tsx
+++ b/src/domain/fld/landsacpe/LandscapeActionPreview.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, useEffect, useRef, useState } from "react";
+import { Dispatch, useEffect, useMemo, useRef } from "react";
 import { useCursorContext } from "../../../common/controls/CursorContext";
 import { useFldMapContext } from "../FldMapContext";
 import { useFldPrimaryActionContext } from "../action-bar/FldPrimaryActionContext";
-import { FldFile, IndexValue, getRelativePoints } from "../FldFile";
+import { FldFile, getRelativePoints } from "../FldFile";
 import { FldAction } from "../FldReducer";
 import { useLandscapeActionContext } from "./LandscapeActionContext";
 import { useLeftClickHoldDelayAction } from "../../../common/controls/useLeftClickHoldDelayAction";
@@ -29,9 +29,9 @@ interface PreviewProps {
 const Preview = (props: PreviewProps) => {
     const { hoveredPoint, fldFile, dispatch } = props;
     const { activeAction, size, height: absoluteHeight, speed: stepsize } = useLandscapeActionContext();
-    const [points, setPoints] = useState<IndexValue[]>([]);
-    const [width, setWidth] = useState<number>(0);
-    const [height, setHeight] = useState<number>(0);
+    const points = useMemo(() => getRelativePoints(fldFile, hoveredPoint, size, size), [fldFile, hoveredPoint, size]);
+    const width = useMemo(() => new Set(points.map((p) => p.index % fldFile.width)).size, [points, fldFile.width]);
+    const height = useMemo(() => new Set(points.map((p) => fldFile.height - 1 - Math.floor(p.index / fldFile.width))).size, [points, fldFile.height, fldFile.width]);
 
     const planeMesh = useRef<Mesh>(null);
     const planeGeo = useRef<PlaneGeometry>(null);
@@ -42,13 +42,6 @@ const Preview = (props: PreviewProps) => {
         speed,
         [points],
     );
-
-    useEffect(() => {
-        const relativePoints = getRelativePoints(fldFile, hoveredPoint, size, size);
-        setPoints(relativePoints);
-        setWidth(new Set(relativePoints.map((p) => p.index % fldFile.width)).size);
-        setHeight(new Set(relativePoints.map((p) => fldFile.height - 1 - Math.floor(p.index / fldFile.width))).size);
-    }, [fldFile, hoveredPoint, size]);
 
     useEffect(() => {
         if (planeGeo.current) {

--- a/src/domain/fld/landsacpe/LandscapeActions.tsx
+++ b/src/domain/fld/landsacpe/LandscapeActions.tsx
@@ -15,13 +15,19 @@ export const LandscapeActions = () => {
     return (
         <Stack
             direction="row"
-            gap="16px"
-            alignItems="center"
-            justifyContent="space-between"
-            height="100%"
-            width="450px"
-        >
-            <Stack direction="row" gap="16px" alignItems="center">
+            sx={{
+                gap: "16px",
+                alignItems: "center",
+                justifyContent: "space-between",
+                height: "100%",
+                width: "450px"
+            }}>
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center"
+                }}>
                 <Tooltip title={t("landscape.fix")}>
                     <IconButton color={getActionColor("FIX", activeAction)} onClick={() => setActiveAction("FIX")}>
                         <GetAppIcon sx={{ fontSize: 32 }} />
@@ -57,7 +63,12 @@ export const LandscapeActions = () => {
                 <Divider orientation="vertical" flexItem />
             </Stack>
 
-            <Stack direction="row" gap="16px" alignItems="center">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    alignItems: "center"
+                }}>
                 {activeAction === "FIX" && (
                     <MinMaxNumberInput
                         label={t("landscape.height")}

--- a/src/domain/fld/resource/ResourceActionButtons.tsx
+++ b/src/domain/fld/resource/ResourceActionButtons.tsx
@@ -11,7 +11,14 @@ export const ResourceActionButtons = () => {
     const { activeResource, setActiveResource, size, setSize } = useResourceActionContext();
 
     return (
-        <Stack direction="row" gap="16px" alignItems="center" height="100%" width="auto">
+        <Stack
+            direction="row"
+            sx={{
+                gap: "16px",
+                alignItems: "center",
+                height: "100%",
+                width: "auto"
+            }}>
             <Tooltip title={t("actions.resource.remove")}>
                 <IconButton
                     color={getActionColor("DELETE", activeResource)}

--- a/src/domain/fld/resource/ResourceActionPreview.tsx
+++ b/src/domain/fld/resource/ResourceActionPreview.tsx
@@ -1,9 +1,9 @@
 import { Color } from "@react-three/fiber";
 import { useFldPrimaryActionContext } from "../action-bar/FldPrimaryActionContext";
 import { ActiveResource, useResourceActionContext } from "./ResourceActionContext";
-import { Dispatch, useEffect, useRef, useState } from "react";
+import { Dispatch, useEffect, useMemo, useRef } from "react";
 import { useCursorContext } from "../../../common/controls/CursorContext";
-import { FldFile, IndexValue, getRelativePoints } from "../FldFile";
+import { FldFile, getRelativePoints } from "../FldFile";
 import { useFldMapContext } from "../FldMapContext";
 import { useLeftClickHoldAction } from "../../../common/controls/useLeftClickHoldAction";
 import { FldAction } from "../FldReducer";
@@ -39,17 +39,12 @@ const Preview = (props: PreviewProps) => {
     const { hoveredPoint, fldFile, dispatch } = props;
     const { width, height } = fldFile;
     const { activeResource, size } = useResourceActionContext();
-    const [points, setPoints] = useState<IndexValue[]>([]);
+    const points = useMemo(() => getRelativePoints(fldFile, hoveredPoint, size, size), [fldFile, hoveredPoint, size]);
     const instancedMeshRef = useRef<InstancedMesh>(null!);
 
     const color = ACTION_COLOR[activeResource];
 
     useLeftClickHoldAction(() => dispatch({ type: "RESOURCE", points, resource: activeResource }), [points]);
-
-    useEffect(() => {
-        const relativePoints = getRelativePoints(fldFile, hoveredPoint, size, size);
-        setPoints(relativePoints);
-    }, [fldFile, hoveredPoint, size]);
 
     useEffect(() => {
         points.forEach((p, i) => {

--- a/src/domain/fld/resource/ResourceActions.ts
+++ b/src/domain/fld/resource/ResourceActions.ts
@@ -11,8 +11,8 @@ export interface ResourcePayload {
     points: IndexValue[];
 }
 
-const addXenit = (oldValue: number): number => (oldValue |= Xenit.LAYER_VALUE);
-const addTritium = (oldValue: number): number => (oldValue |= Tritium.LAYER_VALUE);
+const addXenit = (oldValue: number): number => oldValue | Xenit.LAYER_VALUE;
+const addTritium = (oldValue: number): number => oldValue | Tritium.LAYER_VALUE;
 const removeResource = (): number => 0;
 const RESOURCE_OPERATION: { [key in ActiveResource]: (oldValue: number) => number } = {
     DELETE: removeResource,

--- a/src/domain/fld/water/WaterActionButtons.tsx
+++ b/src/domain/fld/water/WaterActionButtons.tsx
@@ -9,7 +9,14 @@ export const WaterActionButtons = () => {
     const { activeAction, setActiveAction } = useWaterActionContext();
 
     return (
-        <Stack direction="row" gap="16px" alignItems="center" height="100%" width="auto">
+        <Stack
+            direction="row"
+            sx={{
+                gap: "16px",
+                alignItems: "center",
+                height: "100%",
+                width: "auto"
+            }}>
             <Tooltip title={t("actions.water.remove")}>
                 <IconButton color={getActionColor("DELETE", activeAction)} onClick={() => setActiveAction("DELETE")}>
                     <InvertColorsOffIcon sx={{ fontSize: 32 }} />

--- a/src/domain/fld/water/WaterActionPreview.tsx
+++ b/src/domain/fld/water/WaterActionPreview.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useEffect, useRef, useState } from "react";
+import { Dispatch, useEffect, useMemo, useRef } from "react";
 import { FldFile, IndexValue } from "../FldFile";
 import { FldAction } from "../FldReducer";
 import { useFldMapContext } from "../FldMapContext";
@@ -38,7 +38,7 @@ const Preview = (props: PreviewProps) => {
     const { hoveredPoint, fldFile, dispatch } = props;
     const { width, height } = fldFile;
     const { activeAction } = useWaterActionContext();
-    const [points, setPoints] = useState<IndexValue[]>([]);
+    const points = useMemo(() => getWaterPuddlePoints(fldFile, hoveredPoint), [fldFile, hoveredPoint]);
     const instancedMeshRef = useRef<InstancedMesh>(null!);
     const speed = 8;
     const color = ACTION_COLOR[activeAction];
@@ -54,11 +54,6 @@ const Preview = (props: PreviewProps) => {
         speed,
         [points],
     );
-
-    useEffect(() => {
-        const relativePoints = getWaterPuddlePoints(fldFile, hoveredPoint);
-        setPoints(relativePoints);
-    }, [fldFile, hoveredPoint]);
 
     useEffect(() => {
         points.forEach((p, i) => {

--- a/src/domain/lev/entities/PlaceEntitySelection.tsx
+++ b/src/domain/lev/entities/PlaceEntitySelection.tsx
@@ -29,7 +29,12 @@ const Content = ({ playerCount, dispatch }: { playerCount: PlayerCount; dispatch
 
     return (
         <div>
-            <Stack direction="row" gap="16px" justifyContent="space-between">
+            <Stack
+                direction="row"
+                sx={{
+                    gap: "16px",
+                    justifyContent: "space-between"
+                }}>
                 <Stack className="owner-selection" direction="row">
                     {placeablePlayers.map((o) => (
                         <div
@@ -41,7 +46,9 @@ const Content = ({ playerCount, dispatch }: { playerCount: PlayerCount; dispatch
                         </div>
                     ))}
                 </Stack>
-                <Stack direction="row" gap="4px">
+                <Stack direction="row" sx={{
+                    gap: "4px"
+                }}>
                     <Tooltip title={t("action.remove-player")}>
                         <IconButton onClick={() => dispatch({ type: "SET_PLAYER_COUNT", count: playerCount - 1 })}>
                             <RemoveIcon sx={{ fontSize: 16 }} />
@@ -54,7 +61,9 @@ const Content = ({ playerCount, dispatch }: { playerCount: PlayerCount; dispatch
                     </Tooltip>
                 </Stack>
             </Stack>
-            <Stack className="place-entity-container" direction="row" gap="8px">
+            <Stack className="place-entity-container" direction="row" sx={{
+                gap: "8px"
+            }}>
                 {buildings.map((b) => (
                     <Stack
                         key={b}

--- a/src/domain/pck/PckDecompressor.ts
+++ b/src/domain/pck/PckDecompressor.ts
@@ -27,12 +27,8 @@ export class PckDecompressor {
         const pTab1 = 16;
         const pTab2 = 16 + 0x100 * 4;
         const pTab3 = 16 + 0x100 * 4 + 0x400 * 4;
-        let a = 0;
         let pB = pTab2;
-        let d = 0;
         let pT = pTab3;
-        let pP = 0;
-        let c = 0;
         const pByteOut = 0;
         let pByteO = 0;
         const pByteInl = compressed.byteLength;

--- a/src/domain/pck/PckDecompressor.ts
+++ b/src/domain/pck/PckDecompressor.ts
@@ -27,8 +27,12 @@ export class PckDecompressor {
         const pTab1 = 16;
         const pTab2 = 16 + 0x100 * 4;
         const pTab3 = 16 + 0x100 * 4 + 0x400 * 4;
+        let a: number;
         let pB = pTab2;
+        let d: number;
         let pT = pTab3;
+        let pP: number;
+        let c: number = 0;
         const pByteOut = 0;
         let pByteO = 0;
         const pByteInl = compressed.byteLength;

--- a/src/domain/pck/PckDecompressor.ts
+++ b/src/domain/pck/PckDecompressor.ts
@@ -32,7 +32,7 @@ export class PckDecompressor {
         let d: number;
         let pT = pTab3;
         let pP: number;
-        let c: number = 0;
+        let c: number;
         const pByteOut = 0;
         let pByteO = 0;
         const pByteInl = compressed.byteLength;

--- a/src/domain/pck/level/LevelPckSelectionContext.tsx
+++ b/src/domain/pck/level/LevelPckSelectionContext.tsx
@@ -39,16 +39,17 @@ export const LevelPckSelectionContextProvider: React.FC<PropsWithChildren> = ({ 
         [fldDispatch, levDispatch, levelPck?.levels],
     );
 
+    if (levelPck && selectedLevelIndex == undefined && levelPck.levels.length > 0) {
+        setSelectedLevelIndex(0);
+    }
+
     useEffect(() => {
-        // select first level when levelPck changes
-        if (levelPck && selectedLevelIndex == undefined && levelPck.levels.length > 0) {
-            const firstLevel = levelPck.levels[0];
-            selectLevel(firstLevel);
-            setSelectedLevelIndex(0);
-        } else if (!levelPck) {
-            setSelectedLevelIndex(undefined);
+        if (levelPck && selectedLevelIndex != undefined && levelPck.levels.length > 0) {
+            const level = levelPck.levels[selectedLevelIndex];
+            fldDispatch({ type: "SET_FLD", fldFile: level.fld });
+            levDispatch({ type: "SET_LEV", levFile: level.lev });
         }
-    }, [levelPck, selectLevel, selectedLevelIndex]);
+    }, [levelPck, selectedLevelIndex, fldDispatch, levDispatch]);
 
     useEffect(() => {
         if (selectedLevelIndex == undefined || levFile == undefined) {

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -29,7 +29,9 @@ export const MainLayout = ({
         <Typography component="div" className="main-layout">
             <AppBar position="static">
                 <Toolbar>
-                    <Typography variant="h6" component="h1" mr={2}>
+                    <Typography variant="h6" component="h1" sx={{
+                        mr: 2
+                    }}>
                         <Link to={HOME} className="link-no-decoration">
                             {t("common.app_name")}
                         </Link>

--- a/src/pages/edit/level/LevelPckFileSelection.tsx
+++ b/src/pages/edit/level/LevelPckFileSelection.tsx
@@ -36,17 +36,23 @@ export const LevelPckFileSelection = (props: PropsWithChildren) => {
 
     return (
         <>
-            <Typography variant="h4" component="h2" display="block" gutterBottom>
+            <Typography variant="h4" component="h2" gutterBottom sx={{
+                display: "block"
+            }}>
                 {title}
             </Typography>
-            <Stack gap="16px">
+            <Stack sx={{
+                gap: "16px"
+            }}>
                 <Card>
                     <CardContent>
                         <H2 variant="h5">{t("lvl-editor.select-file")}</H2>
                         <span>
                             Choose your existing <em>level.pck</em> or <em>level00.pck</em> to get started.
                         </span>
-                        <Stack direction="row" justifyContent="end">
+                        <Stack direction="row" sx={{
+                            justifyContent: "end"
+                        }}>
                             <SelectFileButton onFileChanged={parsePckFile} accept=".pck" disabled={isParsing}>
                                 Select
                             </SelectFileButton>

--- a/src/pages/extract-pck/PagePckExtractor.tsx
+++ b/src/pages/extract-pck/PagePckExtractor.tsx
@@ -44,10 +44,14 @@ const PagePckExtractor = () => {
 
     return (
         <MainLayout mainMaxWidth={900}>
-            <Typography variant="h3" component="h2" display="block" gutterBottom>
+            <Typography variant="h3" component="h2" gutterBottom sx={{
+                display: "block"
+            }}>
                 {pckExtractor}
             </Typography>
-            <Stack gap="16px">
+            <Stack sx={{
+                gap: "16px"
+            }}>
                 <ParseFailedError failed={parseFailed} />
                 <AboutCard onFileChanged={handleFileChanged} disableSelection={isParsing} />
                 <PckHeaderInfo file={pckFile} selectedFile={selectedFile} isLoading={isParsing} />

--- a/src/pages/extract-pck/components/AboutCard.tsx
+++ b/src/pages/extract-pck/components/AboutCard.tsx
@@ -15,7 +15,9 @@ export const AboutCard = (props: AboutCardProps) => {
             <CardContent>
                 <p>{t("pck-extractor.short-description")}</p>
 
-                <Stack direction="row" justifyContent="end">
+                <Stack direction="row" sx={{
+                    justifyContent: "end"
+                }}>
                     <SelectFileButton onFileChanged={onFileChanged} accept=".pck" disabled={disableSelection}>
                         {t("pck-extractor.extract-pck-file")}
                     </SelectFileButton>

--- a/src/pages/extract-pck/components/PckHeaderInfo.tsx
+++ b/src/pages/extract-pck/components/PckHeaderInfo.tsx
@@ -58,7 +58,9 @@ export const PckHeaderInfo = (props: PckHeaderInfoProps) => {
                     )}
                 </ul>
                 {isLoading && (
-                    <Stack direction="row" justifyContent="center">
+                    <Stack direction="row" sx={{
+                        justifyContent: "center"
+                    }}>
                         <CircularProgress disableShrink />
                     </Stack>
                 )}

--- a/src/pages/flm-decoder/PageFlmDecoder.tsx
+++ b/src/pages/flm-decoder/PageFlmDecoder.tsx
@@ -78,10 +78,14 @@ const PageFlmDecoder = () => {
 
     return (
         <MainLayout mainMaxWidth={900}>
-            <Typography variant="h3" component="h2" display="block" gutterBottom>
+            <Typography variant="h3" component="h2" gutterBottom sx={{
+                display: "block"
+            }}>
                 {title}
             </Typography>
-            <Stack gap="16px">
+            <Stack sx={{
+                gap: "16px"
+            }}>
                 <ParseFailedError failed={parseFailed} />
                 <AboutCard onFileChanged={handleFileChanged} disableSelection={isParsing} />
                 <VideoFFmpegCard />

--- a/src/pages/flm-decoder/components/AboutCard.tsx
+++ b/src/pages/flm-decoder/components/AboutCard.tsx
@@ -15,7 +15,9 @@ export const AboutCard = (props: AboutCardProps) => {
             <CardContent>
                 <p>{t("flm-extractor.description-short")}</p>
 
-                <Stack direction="row" justifyContent="end">
+                <Stack direction="row" sx={{
+                    justifyContent: "end"
+                }}>
                     <SelectFileButton onFileChanged={onFileChanged} accept=".flm" disabled={disableSelection}>
                         {t("flm-extractor.select-file")}
                     </SelectFileButton>

--- a/src/pages/home/PageHome.tsx
+++ b/src/pages/home/PageHome.tsx
@@ -15,18 +15,30 @@ const PageHome = () => {
     usePageTitle(home);
     return (
         <MainLayout>
-            <Stack gap="32px" direction="column">
+            <Stack direction="column" sx={{
+                gap: "32px"
+            }}>
                 <Typography variant="h3" component="h2" gutterBottom>
                     {home}
                 </Typography>
-                <Stack gap="32px" direction="row" flexWrap="wrap">
+                <Stack
+                    direction="row"
+                    sx={{
+                        gap: "32px",
+                        flexWrap: "wrap"
+                    }}>
                     <LevelEditorCard />
                     <FldEditorCard />
                 </Stack>
                 <Typography variant="h3" component="h2" gutterBottom>
                     {t("common.extractors")}
                 </Typography>
-                <Stack gap="32px" direction="row" flexWrap="wrap">
+                <Stack
+                    direction="row"
+                    sx={{
+                        gap: "32px",
+                        flexWrap: "wrap"
+                    }}>
                     <PckExtractorCard />
                     <SamDecoderCard />
                     <FlmDecoderCard />

--- a/src/pages/home/components/HomeCard.tsx
+++ b/src/pages/home/components/HomeCard.tsx
@@ -17,7 +17,9 @@ export const HomeCard = ({ description, imgUrl, linkDest, linkText, title }: Hom
                 <Typography gutterBottom variant="h5" component="h3">
                     {title}
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {description}
                 </Typography>
             </CardContent>

--- a/src/pages/sam-decoder/PageSamDecoder.tsx
+++ b/src/pages/sam-decoder/PageSamDecoder.tsx
@@ -44,10 +44,14 @@ const PageSamDecoder = () => {
 
     return (
         <MainLayout mainMaxWidth={900}>
-            <Typography variant="h3" component="h2" display="block" gutterBottom>
+            <Typography variant="h3" component="h2" gutterBottom sx={{
+                display: "block"
+            }}>
                 {samDecoder}
             </Typography>
-            <Stack gap="16px">
+            <Stack sx={{
+                gap: "16px"
+            }}>
                 <ParseFailedError failed={parseFailed} />
                 <AboutCard onFileChanged={handleFileChanged} disableSelection={isParsing} />
                 {pcmData && <SamPlayer pcmDataView={pcmData} />}

--- a/src/pages/sam-decoder/components/SamSelectFileCard.tsx
+++ b/src/pages/sam-decoder/components/SamSelectFileCard.tsx
@@ -15,7 +15,9 @@ export const AboutCard = (props: AboutCardProps) => {
             <CardContent>
                 <p>{t("sam-decoder.short-description")}</p>
 
-                <Stack direction="row" justifyContent="end">
+                <Stack direction="row" sx={{
+                    justifyContent: "end"
+                }}>
                     <SelectFileButton onFileChanged={onFileChanged} accept=".sam" disabled={disableSelection}>
                         {t("sam-decoder.select-file")}
                     </SelectFileButton>


### PR DESCRIPTION
- Remove unused variables in PckDecompressor (a, d, pP, c)
- Replace useless |= with | in ResourceActions (addXenit, addTritium)
- Remove unused local_28 in FlmUtils
- Remove useless final toIndex++ in HeaderUtils
- Remove useless zoomChanged = false in OrbitControls
- Replace useState+useEffect with useMemo in 5 preview components (Debug3x3Box, GenericActionPreview, ResourceActionPreview, WaterActionPreview, LandscapeActionPreview)
- Fix ChooseFldDialog with render-time state adjustment
- Split LevelPckSelectionContext state updates from side effects
- Replace useState with useRef in control hooks (useLeftClickAction, useLeftClickHoldDelayAction, useKeyboardHoldDelayAction)