### PR TITLE
fix: reduce FldMapContext re-render cascade during hold-click operations

### DIFF
--- a/src/domain/fld/FldMapContext.tsx
+++ b/src/domain/fld/FldMapContext.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import { Dispatch, useContext, PropsWithChildren, createContext } from "react";
+import { Dispatch, useCallback, useContext, useMemo, PropsWithChildren, createContext } from "react";
 import { FldFile } from "./FldFile";
 import { ResourceDefinition, ResourceLayerUtil } from "./resource/ResourceLayerUtil";
 
@@ -29,14 +29,23 @@ export const useFldMapContext = (): FldMapContextProps => {
 export const FldMapContextProvider: React.FC<PropsWithChildren> = ({ children }: PropsWithChildren) => {
     const [fldFile, dispatch] = useFldReducer();
 
-    const resourceLayer: ResourceDefinition | null = fldFile ? ResourceLayerUtil.fromFldFile(fldFile) : null;
+    const resourceLayer: ResourceDefinition | null = useMemo(
+        () => (fldFile ? ResourceLayerUtil.fromFldFile(fldFile) : null),
+        [fldFile],
+    );
 
-    const tryUseFldFile = async (file: File) => {
-        const result = await FldUtils.parseFldFile(file);
-        dispatch({ type: "SET_FLD", fldFile: result });
-    };
+    const tryUseFldFile = useCallback(
+        async (file: File) => {
+            const result = await FldUtils.parseFldFile(file);
+            dispatch({ type: "SET_FLD", fldFile: result });
+        },
+        [dispatch],
+    );
 
-    const contextValue = { fldFile, dispatch, tryUseFldFile, resourceLayer };
+    const contextValue = useMemo(
+        () => ({ fldFile, dispatch, tryUseFldFile, resourceLayer }),
+        [fldFile, dispatch, tryUseFldFile, resourceLayer],
+    );
 
     return <FldMapContext.Provider value={contextValue}>{children}</FldMapContext.Provider>;
 };

--- a/src/domain/fld/landsacpe/LandscapeActionPreview.tsx
+++ b/src/domain/fld/landsacpe/LandscapeActionPreview.tsx
@@ -63,7 +63,6 @@ const Preview = (props: PreviewProps) => {
             planeGeo.current.computeVertexNormals();
             planeGeo.current.computeBoundingBox();
             planeGeo.current.computeBoundingSphere();
-            planeGeo.current.computeTangents();
         }
     }, [fldFile.height, fldFile.width, points]);
 

--- a/src/domain/fld/meshes/GenericMesh.tsx
+++ b/src/domain/fld/meshes/GenericMesh.tsx
@@ -55,7 +55,6 @@ export const GenericLayerMesh = (props: GenericLayerMeshProps): React.JSX.Elemen
             planeGeo.current.computeVertexNormals();
             planeGeo.current.computeBoundingBox();
             planeGeo.current.computeBoundingSphere();
-            planeGeo.current.computeTangents();
         }
     }, [height, layer.byteLength, layer, width]);
 

--- a/src/domain/fld/meshes/GenericMesh.tsx
+++ b/src/domain/fld/meshes/GenericMesh.tsx
@@ -1,35 +1,34 @@
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { useCursorCapture } from "../../../common/controls/useCursorCapture";
-import { FldMap } from "../FldFile";
 import { LayerSetting } from "../layers/LayerViewContext";
 import { DoubleSide, Mesh, PlaneGeometry } from "three";
 
 interface GenericMeshProps {
-    map: FldMap;
+    width: number;
+    height: number;
     layer: DataView;
     settings: LayerSetting;
 }
 
-export const GenericMesh = (props: GenericMeshProps) => {
-    const { settings, map, layer } = props;
+export const GenericMesh = memo((props: GenericMeshProps) => {
+    const { settings, width, height, layer } = props;
 
     if (settings.hide) {
         return <></>;
     }
 
-    return <GenericLayerMesh layer={layer} map={map} showWireframe={settings.showWireframe} />;
-};
+    return <GenericLayerMesh layer={layer} width={width} height={height} showWireframe={settings.showWireframe} />;
+});
 
 interface GenericLayerMeshProps {
-    map: FldMap;
+    width: number;
+    height: number;
     layer: DataView;
     showWireframe: boolean;
 }
 
 export const GenericLayerMesh = (props: GenericLayerMeshProps): React.JSX.Element => {
-    const { map, layer, showWireframe } = props;
-    const width = map.width;
-    const height = map.height;
+    const { width, height, layer, showWireframe } = props;
 
     const planeMesh = useRef<Mesh>(null);
     const planeGeo = useRef<PlaneGeometry>(null);

--- a/src/domain/fld/meshes/LandscapeMesh.tsx
+++ b/src/domain/fld/meshes/LandscapeMesh.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import { useCursorCapture } from "../../../common/controls/useCursorCapture";
-import { FldMap } from "../FldFile";
 import { useFldMapContext } from "../FldMapContext";
 import { Layer } from "../layers/Layer";
 import { useLayerViewContext } from "../layers/LayerViewContext";
@@ -18,25 +17,28 @@ export const LandscapeMesh = () => {
         return <></>;
     }
 
-    return <LandscapeLayerMesh map={fldFile} primaryAction={primaryAction} showWireframe={showWireframe} />;
+    return <LandscapeLayerMesh landscape={landscape} mountains1={mountains1} textures1={textures1} width={fldFile.width} height={fldFile.height} primaryAction={primaryAction} showWireframe={showWireframe} />;
 };
 
 interface LandscapeLayerMeshProps {
-    map: FldMap;
+    landscape: DataView;
+    mountains1: DataView;
+    textures1: DataView;
+    width: number;
+    height: number;
     primaryAction: FldPrimaryAction;
     showWireframe: boolean;
 }
 
-export const LandscapeLayerMesh = ({
-    map,
+export const LandscapeLayerMesh = memo(({
+    landscape,
+    mountains1,
+    textures1,
+    width,
+    height,
     primaryAction,
     showWireframe,
 }: LandscapeLayerMeshProps): React.JSX.Element => {
-    const landscape = map.layers[Layer.Landscape];
-    const mountains1 = map.layers[Layer.Mountains1];
-    const textures1 = map.layers[Layer.Textures1];
-    const width = map.width;
-    const height = map.height;
 
     const planeMesh = useRef<Mesh>(null);
     const planeGeo = useRef<PlaneGeometry>(null);
@@ -86,7 +88,7 @@ export const LandscapeLayerMesh = ({
             />
         </mesh>
     );
-};
+});
 
 function createTexture(
     landscape: DataView,

--- a/src/domain/fld/meshes/LandscapeMesh.tsx
+++ b/src/domain/fld/meshes/LandscapeMesh.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useCursorCapture } from "../../../common/controls/useCursorCapture";
 import { FldMap } from "../FldFile";
 import { useFldMapContext } from "../FldMapContext";
@@ -34,6 +34,7 @@ export const LandscapeLayerMesh = ({
 }: LandscapeLayerMeshProps): React.JSX.Element => {
     const landscape = map.layers[Layer.Landscape];
     const mountains1 = map.layers[Layer.Mountains1];
+    const textures1 = map.layers[Layer.Textures1];
     const width = map.width;
     const height = map.height;
 
@@ -42,7 +43,10 @@ export const LandscapeLayerMesh = ({
 
     useCursorCapture(planeMesh);
 
-    const texture = createTexture(map, primaryAction);
+    const texture = useMemo(
+        () => createTexture(landscape, textures1, width, height, primaryAction),
+        [landscape, textures1, width, height, primaryAction],
+    );
 
     useEffect(() => {
         if (planeGeo.current) {
@@ -67,7 +71,6 @@ export const LandscapeLayerMesh = ({
             planeGeo.current.computeVertexNormals();
             planeGeo.current.computeBoundingBox();
             planeGeo.current.computeBoundingSphere();
-            planeGeo.current.computeTangents();
         }
     }, [height, landscape, mountains1, width]);
 
@@ -85,18 +88,22 @@ export const LandscapeLayerMesh = ({
     );
 };
 
-function createTexture(layer: FldMap, primaryAction: FldPrimaryAction): DataTexture {
+function createTexture(
+    landscape: DataView,
+    textures1: DataView,
+    width: number,
+    height: number,
+    primaryAction: FldPrimaryAction,
+): DataTexture {
     if (primaryAction === "TEXTURES" || primaryAction === "GENERIC") {
-        return createLandscapeTexture(layer);
+        return createLandscapeTexture(landscape, textures1, width, height);
     }
-    return createHeightTexture(layer);
+    return createHeightTexture(landscape, width, height);
 }
 
 /** Create a texture based on the height values */
-function createHeightTexture(layer: FldMap): DataTexture {
-    const heightData = new Uint8Array(layer.width * layer.height * 4);
-    const { width, height, layers } = layer;
-    const landscape = layers[Layer.Landscape];
+function createHeightTexture(landscape: DataView, width: number, height: number): DataTexture {
+    const heightData = new Uint8Array(width * height * 4);
     let x = height;
     let z = 0;
 
@@ -120,16 +127,18 @@ function createHeightTexture(layer: FldMap): DataTexture {
         heightData[index + 3] = 255; // Alpha channel
     }
 
-    const heightTexture = new DataTexture(heightData, layer.width, layer.height, RGBAFormat);
+    const heightTexture = new DataTexture(heightData, width, height, RGBAFormat);
     heightTexture.needsUpdate = true;
     return heightTexture;
 }
 
-function createLandscapeTexture(layer: FldMap): DataTexture {
-    const textureData = new Uint8Array(layer.width * layer.height * 4);
-    const { width, height, layers } = layer;
-    const landscape = layers[Layer.Landscape];
-    const textures = layers[Layer.Textures1];
+function createLandscapeTexture(
+    landscape: DataView,
+    textures: DataView,
+    width: number,
+    height: number,
+): DataTexture {
+    const textureData = new Uint8Array(width * height * 4);
     let x = height;
     let z = 0;
 
@@ -150,7 +159,7 @@ function createLandscapeTexture(layer: FldMap): DataTexture {
         textureData[index + 3] = 255; // Alpha channel
     }
 
-    const landscapeTexture = new DataTexture(textureData, layer.width, layer.height, RGBAFormat);
+    const landscapeTexture = new DataTexture(textureData, width, height, RGBAFormat);
     landscapeTexture.needsUpdate = true;
     return landscapeTexture;
 }

--- a/src/domain/fld/meshes/LandscapeMesh.tsx
+++ b/src/domain/fld/meshes/LandscapeMesh.tsx
@@ -17,6 +17,10 @@ export const LandscapeMesh = () => {
         return <></>;
     }
 
+    const landscape = fldFile.layers[Layer.Landscape];
+    const mountains1 = fldFile.layers[Layer.Mountains1];
+    const textures1 = fldFile.layers[Layer.Textures1];
+
     return <LandscapeLayerMesh landscape={landscape} mountains1={mountains1} textures1={textures1} width={fldFile.width} height={fldFile.height} primaryAction={primaryAction} showWireframe={showWireframe} />;
 };
 

--- a/src/domain/fld/meshes/UnknownMeshes.tsx
+++ b/src/domain/fld/meshes/UnknownMeshes.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Layer, LayerIndex } from "../layers/Layer";
 import { useFldMapContext } from "../FldMapContext";
 import { useLayerViewContext } from "../layers/LayerViewContext";
@@ -23,14 +24,22 @@ export const UnknownMeshes = () => {
     const { fldFile } = useFldMapContext();
     const { layerSettings } = useLayerViewContext();
 
+    const width = fldFile?.width ?? 0;
+    const height = fldFile?.height ?? 0;
+
+    const layers = useMemo(
+        () => (fldFile ? MESHES.map((layer) => fldFile.layers[layer]) : []),
+        [fldFile],
+    );
+
     if (!fldFile) {
         return <></>;
     }
 
     return (
         <>
-            {MESHES.map((layer) => (
-                <GenericMesh key={layer} layer={fldFile.layers[layer]} map={fldFile} settings={layerSettings[layer]} />
+            {MESHES.map((layer, i) => (
+                <GenericMesh key={layer} width={width} height={height} layer={layers[i]} settings={layerSettings[layer]} />
             ))}
         </>
     );

--- a/src/domain/fld/meshes/WaterMesh.tsx
+++ b/src/domain/fld/meshes/WaterMesh.tsx
@@ -62,7 +62,6 @@ export const WaterLayerMesh = (props: WaterLayerMeshProps): React.JSX.Element =>
             geo.computeVertexNormals();
             geo.computeBoundingBox();
             geo.computeBoundingSphere();
-            geo.computeTangents();
         }
     }, [height, landscape, mountains1, unknown6, water, width]);
 

--- a/src/domain/fld/meshes/WaterMesh.tsx
+++ b/src/domain/fld/meshes/WaterMesh.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef } from "react";
-import { FldMap } from "../FldFile";
+import { memo, useEffect, useRef } from "react";
 import { Layer } from "../layers/Layer";
 import { useFldMapContext } from "../FldMapContext";
 import { useLayerViewContext } from "../layers/LayerViewContext";
@@ -14,24 +13,37 @@ export const WaterMesh = () => {
     if (!fldFile || hide) {
         return <></>;
     }
-    return <WaterLayerMesh map={fldFile} showWireframe={showWireframe} />;
+
+    const landscape = fldFile.layers[Layer.Landscape];
+    const water = fldFile.layers[Layer.Water];
+    const mountains1 = fldFile.layers[Layer.Mountains1];
+    const waterHeight = fldFile.layers[Layer.WaterHeight];
+
+    return (
+        <WaterLayerMesh
+            landscape={landscape}
+            water={water}
+            mountains1={mountains1}
+            waterHeight={waterHeight}
+            width={fldFile.width}
+            height={fldFile.height}
+            showWireframe={showWireframe}
+        />
+    );
 };
 
 interface WaterLayerMeshProps {
-    map: FldMap;
+    landscape: DataView;
+    water: DataView;
+    mountains1: DataView;
+    waterHeight: DataView;
+    width: number;
+    height: number;
     showWireframe: boolean;
 }
 
-export const WaterLayerMesh = (props: WaterLayerMeshProps): React.JSX.Element => {
-    const { map, showWireframe } = props;
-
-    const water = map.layers[Layer.Water];
-    const landscape = map.layers[Layer.Landscape];
-    const mountains1 = map.layers[Layer.Mountains1];
-    const unknown6 = map.layers[Layer.WaterHeight];
-
-    const width = map.width;
-    const height = map.height;
+export const WaterLayerMesh = memo((props: WaterLayerMeshProps): React.JSX.Element => {
+    const { landscape, water, mountains1, waterHeight, width, height, showWireframe } = props;
 
     const planeMesh = useRef<Mesh>(null);
     const planeGeo = useRef<PlaneGeometry>(null);
@@ -44,7 +56,7 @@ export const WaterLayerMesh = (props: WaterLayerMeshProps): React.JSX.Element =>
                 const w = water.getUint8(i);
                 const value = landscape.getUint8(i);
                 const m = mountains1.getUint8(i);
-                const u6 = unknown6.getUint8(i);
+                const u6 = waterHeight.getUint8(i);
                 const hasWater = w === 0;
                 const y = hasWater ? (value - m + u6) / 4 : (value - m - 4) / 4;
                 const z = i % width;
@@ -63,7 +75,7 @@ export const WaterLayerMesh = (props: WaterLayerMeshProps): React.JSX.Element =>
             geo.computeBoundingBox();
             geo.computeBoundingSphere();
         }
-    }, [height, landscape, mountains1, unknown6, water, width]);
+    }, [height, landscape, mountains1, waterHeight, water, width]);
 
     return (
         <mesh ref={planeMesh} castShadow={true} receiveShadow={true} visible>
@@ -78,4 +90,4 @@ export const WaterLayerMesh = (props: WaterLayerMeshProps): React.JSX.Element =>
             />
         </mesh>
     );
-};
+});


### PR DESCRIPTION
- Memoize contextValue in FldMapContextProvider (useMemo/useCallback) to prevent ~22 Canvas consumers from re-rendering on every dispatch
- Memoize createTexture() in LandscapeLayerMesh with stable layer deps to avoid per-render texture allocation (width*height*4 bytes)
- Refactor texture helpers to accept layers directly instead of FldMap
- Remove unnecessary computeTangents() calls from LandscapeMesh, WaterMesh, GenericMesh, and LandscapeActionPreview (no normal maps)