### PR TITLE
fix: suppress react/no-unknown-property false positives for react-three-fiber

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -13,7 +13,29 @@ export default defineConfig({
 
     // React rules
     "react/jsx-no-target-blank": "warn",
-    "react/no-unknown-property": "warn",
+    "react/no-unknown-property": [
+      "warn",
+      {
+        // Ignore properties used by react-three-fiber (Three.js) that are not in the DOM spec
+        ignore: [
+          "args",
+          "castShadow",
+          "receiveShadow",
+          "visible",
+          "transparent",
+          "roughness",
+          "opacity",
+          "side",
+          "wireframe",
+          "position",
+          "object",
+          "intensity",
+          "target",
+          "color",
+          "map",
+        ],
+      },
+    ],
     "react/react-in-jsx-scope": "off",
 
     // React hooks rules (from eslint-plugin-react-hooks)


### PR DESCRIPTION
The rule assumes all lowercase JSX elements are standard HTML/SVG. React-three-fiber uses lowercase names mapping to Three.js objects, causing valid props like args, castShadow, roughness, etc. to be flagged as unknown. Added ignore list for Three.js-specific properties.